### PR TITLE
prevent checking if peds are dead when unloading/deleting peds

### DIFF
--- a/src/client/main.lua
+++ b/src/client/main.lua
@@ -17,6 +17,7 @@ playerData = {
 }
 
 gameData = {
+    isCurrentlyUnloadingPeds = false,
     isPlaying = false,
     level = 1,
     peds = {}, -- {{model: model, coords: coords}}
@@ -171,7 +172,7 @@ function handleGameEndingConditionsIfNeeded(newPlayerData)
 end
 
 function areAnyPatientsDead()
-    return Stream.of(gameData.peds)
+    return (not gameData.isCurrentlyUnloadingPeds) and Stream.of(gameData.peds)
         .anyMatch(function(patient) return Wrapper.IsPedDeadOrDying(patient.model, 1) end)
 end
 
@@ -276,10 +277,12 @@ end
 function handlePatientDropOff()
     displayMessageAndWaitUntilStopped('stop_ambulance_dropoff')
 
+    gameData.isCurrentlyUnloadingPeds = true
     local numberDroppedOff = #gameData.pedsInAmbulance
     Peds.DeletePeds(mapPedsToModel(gameData.pedsInAmbulance))
     gameData.pedsInAmbulance = {}
     updateMarkersAndBlips()
+    gameData.isCurrentlyUnloadingPeds = false
 
     if #gameData.peds == 0 then
         gameData.secondsLeft = Config.InitialSeconds


### PR DESCRIPTION
`IsPedDeadOrDying` returns true when a ped has been deleted. this check happens on a separate thread, potentially allowing this to be called on peds that have been deleted by the main thread, when unloading patients at the hospital.

this fix should skip the `areAnyPedsDead` check when unloading peds at the hospital.